### PR TITLE
Update filter restore explanation for gulp-filter 3.0.0+.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ var uglify = require('gulp-uglify');
 var gulpFilter = require('gulp-filter');
 
 gulp.task('main-bower-files', function() {
-    var filterJS = gulpFilter('**/*.js');
+    var filterJS = gulpFilter('**/*.js', { restore: true });
     return gulp.src('./bower.json')
         .pipe(mainBowerFiles({
             overrides: {
@@ -80,7 +80,7 @@ gulp.task('main-bower-files', function() {
         .pipe(filterJS)
         .pipe(concat('vendor.js'))
         .pipe(uglify())
-        .pipe(filterJS.restore())
+        .pipe(filterJS.restore)
         .pipe(gulp.dest('./wwwroot/libs'));
 });
 ```


### PR DESCRIPTION
Being new to `gulp` I couldn't immediately figure out why the example didn't work. Then I found out that in [gulp-filter](https://github.com/sindresorhus/gulp-filter) 3.0.0 the `restore` option works a little different.