### PR TITLE
Add node.js file stats to vinyl output objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ module.exports = function (filter, opts, callback) {
                 var newFile = file.clone();
                 newFile.path = fileName;
                 newFile.contents = fs.readFileSync(newFile.path);
+                newFile.stat = fs.statSync(newFile.path);
                 this.push(newFile);
             }, this);
         }


### PR DESCRIPTION
adding the file stats to the output allows plugins further down the pipeline, like gulp-newer, to get the correct modified time for the files